### PR TITLE
Install BN SecureDev CI agents

### DIFF
--- a/.github/bn-drift-monitor.yml
+++ b/.github/bn-drift-monitor.yml
@@ -1,0 +1,2 @@
+product_slug: "terraform-aws-ecs-boomi-molecule"
+schedule: "daily"

--- a/.github/bn-securedev.yml
+++ b/.github/bn-securedev.yml
@@ -1,0 +1,36 @@
+version: '2.0'
+slug: terraform-aws-ecs-boomi-molecule
+ref: v1
+agents:
+  pr-review:
+    enabled: true
+    exclude_paths:
+    - docs/**
+    - '*.md'
+    severity_threshold: medium
+    blocking_threshold: critical
+    max_findings: 20
+  code-review:
+    enabled: false
+    exclude_paths:
+    - docs/**
+    - '*.md'
+    - '**/*.test.*'
+    max_findings: 20
+    focus: all
+  prompt:
+    enabled: false
+  vuln-hunter:
+    enabled: true
+    schedule: monthly
+    scope:
+    - /
+    exclude_paths:
+    - '**/node_modules/'
+    - '**/*.test.*'
+    - '**/*.spec.*'
+    - '**/build/'
+    max_files_per_segment: 200
+  drift-monitor:
+    enabled: true
+    schedule: daily

--- a/.github/bn-security-review.yml
+++ b/.github/bn-security-review.yml
@@ -1,0 +1,7 @@
+product_slug: "terraform-aws-ecs-boomi-molecule"
+severity_threshold: medium
+blocking_threshold: critical
+exclude_paths:
+  - "docs/**"
+  - "*.md"
+max_findings: 20

--- a/.github/bn-vuln-hunter.yml
+++ b/.github/bn-vuln-hunter.yml
@@ -1,0 +1,10 @@
+product_slug: "terraform-aws-ecs-boomi-molecule"
+schedule: "monthly"
+scope:
+  - "/"
+exclude_paths:
+  - "**/node_modules/"
+  - "**/*.test.*"
+  - "**/*.spec.*"
+  - "**/build/"
+max_files_per_segment: 200

--- a/.github/workflows/bn-drift-monitor.yml
+++ b/.github/workflows/bn-drift-monitor.yml
@@ -1,0 +1,28 @@
+# Managed by bn-securedev-cicd installer. Manual edits below this line are preserved.
+# bn-securedev: agent=bn-drift-monitor version=v1
+name: BN Drift Monitor
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+concurrency:
+  group: bn-drift-monitor-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'scheduled' }}
+  cancel-in-progress: true
+jobs:
+  drift-check:
+    if: ${{ !contains(github.event.pull_request.title, '[skip-drift]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: barracuda-internal/bn-securedev-cicd/actions/bn-drift-monitor@v1
+        with:
+          api-key: ${{ secrets.IQ_API_KEY }}

--- a/.github/workflows/bn-security-review.yml
+++ b/.github/workflows/bn-security-review.yml
@@ -1,0 +1,23 @@
+# Managed by bn-securedev-cicd installer. Manual edits below this line are preserved.
+# bn-securedev: agent=bn-security-review version=v1
+name: BN Security Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+concurrency:
+  group: bn-security-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  security-review:
+    if: ${{ !contains(github.event.pull_request.title, '[skip-security]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: barracuda-internal/bn-securedev-cicd/actions/bn-security-review@v1
+        with:
+          api-key: ${{ secrets.IQ_API_KEY }}

--- a/.github/workflows/bn-vuln-hunter.yml
+++ b/.github/workflows/bn-vuln-hunter.yml
@@ -1,0 +1,22 @@
+# Managed by bn-securedev-cicd installer. Manual edits below this line are preserved.
+# bn-securedev: agent=bn-vuln-hunter version=v1
+name: BN Vuln Hunter
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+concurrency:
+  group: bn-vuln-hunter-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  vuln-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: barracuda-internal/bn-securedev-cicd/actions/bn-vuln-hunter@v1
+        with:
+          api-key: ${{ secrets.IQ_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ providers/*
 providers
 modules/aws
 modules/aws/*
+
+# BN SecureDev Toolkit — agent output and state
+.bn-securedev/


### PR DESCRIPTION
## Install BN SecureDev CI agents

Installs the following agents via composite actions from `barracuda-internal/bn-securedev-cicd@v1`:

- [x] bn-security-review
- [x] bn-vuln-hunter
- [x] bn-drift-monitor

**Next step:** Add `IQ_API_KEY` to repo secrets (Settings → Secrets → Actions).

---
_Generated by bn-securedev-cicd installer v2.0_